### PR TITLE
Some tweaks to the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,33 +12,39 @@ issue](https://github.com/ropensci-review-tools/pkgcheck/issues).
 If you'd like to contribute changes to `pkgcheck`, we use [the GitHub
 flow](https://guides.github.com/introduction/flow/index.html) for proposing,
 submitting, reviewing, and accepting changes. If you haven't done this before,
-there's a nice overview of git [here](http://r-pkgs.had.co.nz/git.html), as well
-as best practices for submitting pull requests
-[here](http://r-pkgs.had.co.nz/git.html#pr-make).
+there's a nice [overview of git](https://r-pkgs.org/git.html), as well
+as [best practices for submitting pull requests](http://r-pkgs.org/git.html#pr-make)
+in the R packages book by Hadley Wickham and Jenny Bryan.
 
-The `pkgcheck` coding style diverges somewhat from [this commonly used R style
-guide](http://adv-r.had.co.nz/Style.html), primarily through judicious use of
+The `pkgcheck` coding style diverges somewhat from [the commonly used tidyverse style
+guide](https://style.tidyverse.org/syntax.html#spacing), primarily through judicious use of
 whitespace, which aims to improve code readability. Code references in
 `pkgcheck` are separated by whitespace, just like words of text. Just like it
 is easier to understand "these three words" than "thesethreewords", code is not
 formatted like this:
+
 ``` r
 these <- three(words(x))
 ```
 rather like this:
+
 ``` r
 these <- three (words (x))
 ```
 
 The position of brackets is then arbitrary, and we could also write
+
 ``` r
 these <- three( words (x))
 ```
+
 `pkgcheck` code opts for the former style, with the natural result that one
 ends up writing
+
 ```r
 this <- function ()
 ```
+
 with a space between `function` and `()`. That's it.
 
 ## Adding new checks
@@ -54,5 +60,5 @@ repository.
 
 We want to encourage a warm, welcoming, and safe environment for contributing to
 this project. See the [code of
-conduct](https://github.com/ropensci-review-tools/pkgcheck/blob/master/CODE_OF_CONDUCT.md) for
+conduct](https://ropensci.org/code-of-conduct/) for
 more information.


### PR DESCRIPTION
* more recent links;
* no [here links](https://webaccess.berkeley.edu/ask-pecan/click-here);
* white lines before code chunks (very subjective).

I was wondering whether there's a styler config / linter of some sort folks could apply to respect your whitespace convention? Or that you'd apply to PR (a PR command à la https://github.com/r-lib/actions/blob/master/examples/pr-commands.yaml).