### PR TITLE
Inactivate gitlab workflow in branches

### DIFF
--- a/.github/workflows/gitlab.yaml
+++ b/.github/workflows/gitlab.yaml
@@ -10,7 +10,11 @@
 
 name: push-to-gitlab
 
-on: push
+on:
+  push:
+    branches:
+      - main
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
I am reminded of https://ropensci.org/blog/2021/04/28/commcall-pkg-community/#4-reduce-workload-for-contributors :grin: 