### PR TITLE
update workflows and trigger pkgcheck-action build

### DIFF
--- a/.github/workflows/check-extra-os.yaml
+++ b/.github/workflows/check-extra-os.yaml
@@ -57,21 +57,10 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-           extra-packages: rcmdcheck
+           extra-packages: any::rcmdcheck
 
       - run: rappdirs::user_cache_dir()
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2
 
-      - name: Show testthat output
-        if: always()
-        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
-        shell: bash
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check

--- a/.github/workflows/check-extra-os.yaml
+++ b/.github/workflows/check-extra-os.yaml
@@ -32,9 +32,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
@@ -55,11 +55,14 @@ jobs:
           make
           sudo make install
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
            extra-packages: rcmdcheck
 
-      - uses: r-lib/actions/check-r-package@v1
+      - run: rappdirs::user_cache_dir()
+        shell: Rscript {0}
+
+      - uses: r-lib/actions/check-r-package@v2
 
       - name: Show testthat output
         if: always()
@@ -68,7 +71,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -32,9 +32,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
@@ -55,11 +55,11 @@ jobs:
           make
           sudo make install
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
            extra-packages: rcmdcheck
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2
 
       - name: Show testthat output
         if: always()
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -60,3 +60,4 @@ jobs:
            extra-packages: any::rcmdcheck
 
       - uses: r-lib/actions/check-r-package@v2
+      

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -57,18 +57,6 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-           extra-packages: rcmdcheck
+           extra-packages: any::rcmdcheck
 
       - uses: r-lib/actions/check-r-package@v2
-
-      - name: Show testthat output
-        if: always()
-        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
-        shell: bash
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,8 +7,8 @@ on:
   pull_request:
     branches:
       - main
-    schedule:
-      - cron: "0 0 * * 1"
+  schedule:
+     - cron: "0 0 * * 1"
     
 jobs:
 
@@ -28,11 +28,31 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1 
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
         context: .
-        push: true
-        tags: mpadge/pkgcheck:latest
-        
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: |
+          mpadge/pkgcheck:latest
+          ghcr.io/ropensci-review-tools/pkgcheck:latest
+
+    - name: Trigger pkgcheck-action build
+      if: ${{ github.event_name != 'pull_request' }}
+      uses: actions/github-script@v5
+      with:
+        script: |
+          await github.rest.actions.createWorkflowDispatch({
+            'ropensci-review-tools',
+            'pkgcheck-action',
+            'publish.yaml',
+            'main',
+          });

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -24,12 +24,14 @@ jobs:
       uses: docker/setup-buildx-action@v1
 
     - name: Login
+      if: ${{ github.event_name != 'pull_request' }}
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Login to GitHub Container Registry
+      if: ${{ github.event_name != 'pull_request' }}
       uses: docker/login-action@v1 
       with:
         registry: ghcr.io

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -16,15 +16,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/pr-fetch@v1
+      - uses: r-lib/actions/pr-fetch@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: roxygen2
 
@@ -38,7 +38,7 @@ jobs:
           git add man/\* NAMESPACE
           git commit -m 'Document'
 
-      - uses: r-lib/actions/pr-push@v1
+      - uses: r-lib/actions/pr-push@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -51,11 +51,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/pr-fetch@v1
+      - uses: r-lib/actions/pr-fetch@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
 
       - name: Install dependencies
         run: Rscript -e 'install.packages("styler");install.packages("remotes"); remotes::install_github("ropensci-review-tools/spaceout")'
@@ -70,6 +70,6 @@ jobs:
           git add \*.R
           git commit -m 'Style'
 
-      - uses: r-lib/actions/pr-push@v1
+      - uses: r-lib/actions/pr-push@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
@@ -40,7 +40,7 @@ jobs:
           make
           sudo make install
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
            extra-packages: covr
 

--- a/inst/pkgcheck.yaml
+++ b/inst/pkgcheck.yaml
@@ -1,0 +1,24 @@
+name: pkgcheck
+
+# This will cancel running jobs once a new run is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+on: 
+  # Manually trigger the Action under Actions/pkgcheck
+  workflow_dispatch:
+  # Run on every push to main
+  push:
+    branch: main
+
+jobs: 
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ropensci-review-tools/pkgcheck-action@main
+        with:
+          # Create an issue containing the pkgcheck results
+          issue-name: 'pkgcheck results'
+          # This would create an issue for each branch this action is run on.
+          # issue-name: 'pkgcheck results - ${{ github.ref_name }}'


### PR DESCRIPTION
As discussed with @mpadge I have updated the workflows a bit:

* also push to ghcr.io
* don't push PR builds 
* have the docker action trigger the build action in pkgcheck-action (as it is in the same org a PAT should not be necessary)
* update r-lib/actions to v2
