### PR TITLE
Update Dockerfile to include rstan, cmdstan and cmdstanr.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -258,7 +258,7 @@ ENV CI="true"
 ENV ROPENSCI="true"
 
 # cmdstan path
-ENV CMDSTAN_PATH="${HOME}/.cmdstan"
+ENV CMDSTAN_PATH="/root/.cmdstan"
 
 # A selection of R packages, including extra stats packages
 RUN install2.r \

--- a/Dockerfile
+++ b/Dockerfile
@@ -257,6 +257,9 @@ ENV NOT_CRAN="true"
 ENV CI="true"
 ENV ROPENSCI="true"
 
+# cmdstan path
+ENV CMDSTAN_PATH="${HOME}/.cmdstan"
+
 # A selection of R packages, including extra stats packages
 RUN install2.r \
   arrow \

--- a/Dockerfile
+++ b/Dockerfile
@@ -269,6 +269,7 @@ RUN install2.r \
   goodpractice \
   lme4 \
   mgcv \
+  rstan \
   Rcpp \
   RcppArmadillo \
   RcppEigen \
@@ -289,6 +290,13 @@ RUN install2.r \
 # This is the format needed to install from GitHub:
 # RUN --mount=type=secret,id=GITHUB_PAT,env=GITHUB_PAT installGithub.r \
 #     ropensci-review-tools/goodpractice
+
+# Install cmdstanr from GitHub
+RUN --mount=type=secret,id=GITHUB_PAT,env=GITHUB_PAT installGithub.r \
+     stan-dev/cmdstanr
+
+# Install cmdstan
+RUN Rscript -e 'cmdstanr::check_cmdstan_toolchain(fix = TRUE); cmdstanr::install_cmdstan()'
 
 # Created in /root/.virtualenvs/r-reticulate:
 RUN Rscript -e 'reticulate::virtualenv_create()'


### PR DESCRIPTION
As suggested by @mpadge [here](https://github.com/ropensci/software-review/issues/697#issuecomment-2796585595), this adds `rstan` and `cmdstanr` R packages to the docker container. It also installs `cmdstan` via `cmdstanr` functions.