### PR TITLE
Add pkgchk_uses_dontrun as a watch check

### DIFF
--- a/R/check-uses-dontrun.R
+++ b/R/check-uses-dontrun.R
@@ -1,0 +1,80 @@
+#' Check if examples use `\dontrun{}`
+#'
+#' This check identifies functions in the package documentation that have
+#' examples using `\dontrun{}`. The use of `\dontrun{}` is discouraged by
+#' CRAN and should only be used the example really cannot be executed
+#' (e.g. because of missing additional software, missing API keys, ...) by
+#' the user. Instead use methods to run the examples conditionally, such as
+#' with the `@examplesIf()` roxygen tag.
+#'
+#' @param checks A 'pkgcheck' object with full \pkg{pkgstats} summary and
+#' \pkg{goodpractice} results.
+#' @return character vector of function names that have examples using `\dontrun{}`.
+#' @noRd
+pkgchk_uses_dontrun <- function(checks) {
+  rd_files <- list.files(
+    fs::path(
+      checks$pkg$path,
+      "man"
+    ),
+    pattern = "\\.Rd$",
+    full.names = TRUE
+  )
+
+  parsed_rds <- lapply(
+    rd_files,
+    tools::parse_Rd,
+    warningCalls = FALSE,
+    macros = FALSE,
+    permissive = TRUE
+  )
+
+  has_dontrun_examples <- vapply(
+    parsed_rds,
+    \(rd) {
+      # get_Rd_meta doesn't get the \dontrun part of the examples section,
+      # so need to look for it manually.
+      # Using as.character() + grepl() may be a bit imprecise, however parsing
+      # the Rd directly is messy, and I think this is sufficient
+      rd_char <- as.character(rd)
+      any(grepl("\\examples", rd_char, fixed = TRUE)) &&
+        any(grepl("\\dontrun", rd_char, fixed = TRUE))
+    },
+    logical(1)
+  )
+
+  fn_names <- if (any(has_dontrun_examples)) {
+    vapply(
+      parsed_rds[has_dontrun_examples],
+      \(rd) {
+        fn_name <- get_Rd_meta(rd, "name")
+        ret <- if (length(fn_name) == 0) "" else fn_name
+        ret
+      },
+      character(1)
+    )
+  } else {
+    character(0)
+  }
+
+  fn_names
+}
+
+output_pkgchk_uses_dontrun <- function(checks) {
+  out <- list(
+    check_pass = length(checks$checks$uses_dontrun) == 0,
+    summary = "",
+    print = ""
+  )
+
+  if (!out$check_pass) {
+    out$summary <- "Examples should not use `\\dontrun{{}}` unless really necessary."
+    out$print <- paste0(
+      "The following functions have examples that use `\\dontrun{{}}`:\n'",
+      paste(checks$checks$uses_dontrun, collapse = "', '"),
+      "'.\nConsider using `@examplesIf()` to conditionally run examples instead."
+    )
+  }
+
+  return(out)
+}

--- a/R/summarise-checks.R
+++ b/R/summarise-checks.R
@@ -142,7 +142,8 @@ order_checks <- function (fns) {
         # additionally explicitly listed below in `watch_checks()`:
         "obsolete_pkg_deps",
         "unique_fn_names",
-        "num_imports"
+        "num_imports",
+        "uses_dontrun"
     )
 
     fns <- fns [which (fns %in% ord)]
@@ -158,7 +159,8 @@ watch_checks <- function (output_fns) {
     watch_list <- c (
         "obsolete_pkg_deps",
         "unique_fn_names",
-        "num_imports"
+        "num_imports",
+        "uses_dontrun"
     )
 
     all_checks [which (all_checks %in% watch_list)]


### PR DESCRIPTION
This closes #238 when merged. 

I thought it made sense for this to be a "watch" check, since there are valid reasons to use `\dontrun{}` in examples.

I didn't add tests as I couldn't see an obvious pattern of how to do it by looking at existing test. I did run this on several of my local packages.

One thing I'm not sure about is the print method - I don't see it getting printed, only the summary, and wasn't sure how to trigger that (i.e., see the list of functions that use `dontrun{}`.

Please see my comment on line 37-38 - I was able to extract the `dontrun{}` sections from the Rd files, but the code is much harder to read. Using `grepl()` on the character representation is clearer and I can't think of a situation where that search would return a false positive or a false negative.

Running it on `pkgcheck` gives:

``` r
library(pkgcheck)
check <- pkgcheck("~/dev/ateucher/pkgcheck/", goodpractice = FALSE)
summary(check)
#> 
#> ── pkgcheck 0.1.2.133 ──────────────────────────────────────────────────────────
#> 
#> ✔ Package name is available
#> ✔ has a 'codemeta.json' file.
#> ✔ has a 'contributing' file.
#> ✔ uses 'roxygen2'.
#> ✔ 'DESCRIPTION' has a URL field.
#> ✔ 'DESCRIPTION' has a BugReports field.
#> ✔ Package has at least one HTML vignette
#> ✔ All functions have examples.
#> ✔ Package has continuous integration checks.
#> ℹ Package has unusually large number of 20 Imports (> 98% of all packages)
#> ℹ Examples should not use `\dontrun{}` unless really necessary.
#> 
#> ℹ Current status:
#> ✔ This package may be submitted.
#> 

check
#> Loading required namespace: goodpractice
#> 
#> ── pkgcheck 0.1.2.133 ──────────────────────────────────────────────────────────
#> 
#> ✔ Package name is available
#> ✔ has a 'codemeta.json' file.
#> ✔ has a 'contributing' file.
#> ✔ uses 'roxygen2'.
#> ✔ 'DESCRIPTION' has a URL field.
#> ✔ 'DESCRIPTION' has a BugReports field.
#> ✔ Package has at least one HTML vignette
#> ✔ All functions have examples.
#> ✔ Package has continuous integration checks.
#> ℹ Package has unusually large number of 20 Imports (> 98% of all packages)
#> ℹ Examples should not use `\dontrun{}` unless really necessary.
#> 
#> ℹ Current status:
#> ✔ This package may be submitted.
#> 
#> 
#> ── git ──
#> 
#> • HEAD: 361fdd17
#> • Default branch: main
#> • Number of commits: 1141
#> • First commit: 15-05-2020
#> • Number of authors: 3
#> 
#> 
#> ── Package Structure ──
#> 
#> ℹ Package uses the following languages:
#> • R: 100%
#> • YAML: 0%
#> 
#> ℹ Package has
#> • 3 authors.
#> • 3 vignettes.
#> • No internal data
#> • 20 imported packages.
#> • 12 exported functions (median 17 lines of code).
#> • 291 non-exported functions (median 18 lines of code).
#> • 2 parameters per function (median).
#> 
#> ── Package statistics ──
#> 
#>                     measure  value percentile noteworthy
#> 1                   files_R   46.0       94.4           
#> 4           files_vignettes    3.0       89.5           
#> 5               files_tests   12.0       89.5           
#> 6                     loc_R 4077.0       92.6           
#> 7             loc_vignettes  489.0       76.1           
#> 8                 loc_tests  451.0       68.9           
#> 9             num_vignettes    3.0       91.3           
#> 12                  n_fns_r  303.0       93.4           
#> 13         n_fns_r_exported   12.0       51.4           
#> 14     n_fns_r_not_exported  291.0       95.4       TRUE
#> 15         n_fns_per_file_r    3.4       56.7           
#> 16        num_params_per_fn    2.0        8.1           
#> 17             loc_per_fn_r   18.0       54.9           
#> 18         loc_per_fn_r_exp   17.0       40.3           
#> 19     loc_per_fn_r_not_exp   18.0       58.1           
#> 20         rel_whitespace_R   22.0       94.3           
#> 21 rel_whitespace_vignettes   17.4       55.3           
#> 22     rel_whitespace_tests   26.8       72.8           
#> 23      doclines_per_fn_exp   26.5       27.0           
#> 24  doclines_per_fn_not_exp    0.0        0.0       TRUE
#> 25     fn_call_network_size  177.0       86.3
#> 
#> ℹ Package network diagram is at ['/Users/andy/Library/Caches/R/pkgcheck/static/pkgcheck_pkgstats361fdd17.html'].
#> 
#> 
#> ── goodpractice ──
#> 
#> ℹ 'goodpractice' not included with these checks
#> 
#> ── Package Versions ──
#> 
#>   pkgstats: 0.2.0.58
#>   pkgcheck: 0.1.2.133

cli::cli_inform(pkgcheck:::print_check(check, "uses_dontrun"))
#> The following functions have examples that use `\dontrun{}`:
#> 'checks_to_markdown', 'get_default_github_branch', 'get_gh_token',
#> 'get_latest_commit', 'logfile_names', 'pkgcheck_bg', 'pkgcheck',
#> 'print.pkgcheck', 'read_pkg_guide', 'render_md2html',
#> 'use_github_action_pkgcheck'. Consider using `@examplesIf()` to conditionally
#> run examples instead.
```

<sup>Created on 2025-06-21 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>