### PR TITLE
Add new check on goodpractice linters

### DIFF
--- a/R/check-lintr.R
+++ b/R/check-lintr.R
@@ -10,10 +10,9 @@
 #' @noRd
 pkgchk_lintr <- function (checks) {
 
-    lintr_checks <- grep ("^lintr_", goodpractice::all_checks (), value = TRUE)
-    lintr_results <- goodpractice::gp (checks$pkg$path, checks = lintr_checks)
+    failed_checks <- goodpractice::failed_checks (checks$goodpractice)
+    grep ("^lintr", failed_checks, value = TRUE)
 
-    goodpractice::failed_checks (lintr_results)
 }
 
 output_pkgchk_lintr <- function (checks) {
@@ -30,11 +29,7 @@ output_pkgchk_lintr <- function (checks) {
     if (out$check_pass) {
         out$summary <- "All goodpractice linters passed."
     } else {
-        out$summary <- paste0 (
-            "These goodpractice linters failed: [",
-            paste (failed, collapse = ", "),
-            "]."
-        )
+        out$summary <- "Some goodpractice linters failed."
     }
 
     return (out)

--- a/R/check-lintr.R
+++ b/R/check-lintr.R
@@ -1,0 +1,41 @@
+#' Check for failed lintr checks in the package.
+#'
+#' This function runs all available `lintr_*` checks from the \pkg{goodpractice} package
+#' on the target package and returns the names of any failed checks.
+#'
+#' @param checks A 'pkgcheck' object with full \pkg{pkgstats} summary and
+#' \pkg{goodpractice} results.
+#' @return Character vector of failed `lintr_*` check names; returns `character(0)`
+#' if all lintr checks pass.
+#' @noRd
+pkgchk_lintr <- function (checks) {
+
+    lintr_checks <- grep ("^lintr_", goodpractice::all_checks (), value = TRUE)
+    lintr_results <- goodpractice::gp (checks$pkg$path, checks = lintr_checks)
+
+    goodpractice::failed_checks (lintr_results)
+}
+
+output_pkgchk_lintr <- function (checks) {
+
+    failed <- checks$checks$lintr
+
+    out <- list (
+        check_pass = length (failed) == 0L,
+        summary = "",
+        print = ""
+    ) # no print method
+
+
+    if (out$check_pass) {
+        out$summary <- "All goodpractice linters passed."
+    } else {
+        out$summary <- paste0 (
+            "These goodpractice linters failed: [",
+            paste (failed, collapse = ", "),
+            "]."
+        )
+    }
+
+    return (out)
+}

--- a/R/pkgcheck-fn.R
+++ b/R/pkgcheck-fn.R
@@ -3,7 +3,7 @@
 #'
 #' @param path Path to local repository
 #' @param goodpractice If `FALSE`, skip most goodpractice checks except
-#' \pkg{linkr} and 'DESCRIPTION' checks. May be useful in development stages to
+#' \pkg{lintr} and 'DESCRIPTION' checks. May be useful in development stages to
 #' more quickly check other aspects.
 #' @param use_cache Checks are cached for rapid retrieval, and only re-run if
 #' the git hash of the local repository changes. Setting `use_cache` to `FALSE`

--- a/R/summarise-checks.R
+++ b/R/summarise-checks.R
@@ -142,7 +142,8 @@ order_checks <- function (fns) {
         # additionally explicitly listed below in `watch_checks()`:
         "obsolete_pkg_deps",
         "unique_fn_names",
-        "num_imports"
+        "num_imports",
+        "lintr"
     )
 
     fns <- fns [which (fns %in% ord)]
@@ -158,7 +159,8 @@ watch_checks <- function (output_fns) {
     watch_list <- c (
         "obsolete_pkg_deps",
         "unique_fn_names",
-        "num_imports"
+        "num_imports",
+        "lintr"
     )
 
     all_checks [which (all_checks %in% watch_list)]

--- a/R/summarise-checks.R
+++ b/R/summarise-checks.R
@@ -129,6 +129,7 @@ order_checks <- function (fns) {
         "global_assign",
         "ci",
         "covr",
+        "lintr",
         "has_scrap",
         "left_assign",
         "renv_activated",
@@ -141,8 +142,7 @@ order_checks <- function (fns) {
         # additionally explicitly listed below in `watch_checks()`:
         "obsolete_pkg_deps",
         "unique_fn_names",
-        "num_imports",
-        "lintr"
+        "num_imports"
     )
 
     fns <- fns [which (fns %in% ord)]
@@ -158,8 +158,7 @@ watch_checks <- function (output_fns) {
     watch_list <- c (
         "obsolete_pkg_deps",
         "unique_fn_names",
-        "num_imports",
-        "lintr"
+        "num_imports"
     )
 
     all_checks [which (all_checks %in% watch_list)]

--- a/man/pkgcheck.Rd
+++ b/man/pkgcheck.Rd
@@ -15,8 +15,9 @@ pkgcheck(
 \arguments{
 \item{path}{Path to local repository}
 
-\item{goodpractice}{If \code{FALSE}, skip goodpractice checks. May be useful in
-development stages to more quickly check other aspects.}
+\item{goodpractice}{If \code{FALSE}, skip most goodpractice checks except
+\pkg{lintr} and 'DESCRIPTION' checks. May be useful in development stages to
+more quickly check other aspects.}
 
 \item{use_cache}{Checks are cached for rapid retrieval, and only re-run if
 the git hash of the local repository changes. Setting \code{use_cache} to \code{FALSE}

--- a/tests/testthat/_snaps/extra-checks/checks-extra.html
+++ b/tests/testthat/_snaps/extra-checks/checks-extra.html
@@ -30,6 +30,7 @@ $(document).ready(function(){
 <li>❌ Package has no HTML vignettes</li>
 <li>❌ These functions do not have examples: [pkgstats_from_archive].</li>
 <li>❌ Package has no continuous integration checks.</li>
+<li>❌ Some goodpractice linters failed.</li>
 <li>❌ Package contains unexpected files.</li>
 <li>❌ Default GitHub branch of ‘master’ is not acceptable.</li>
 <li>✅ This is a statistical package which complies with all applicable standards</li>

--- a/tests/testthat/_snaps/extra-checks/checks-extra.md
+++ b/tests/testthat/_snaps/extra-checks/checks-extra.md
@@ -12,6 +12,7 @@ git hash: [](https://github.com/ropensci-review-tools/pkgstats/tree/)
 - :heavy_multiplication_x: Package has no HTML vignettes
 - :heavy_multiplication_x: These functions do not have examples: [pkgstats_from_archive].
 - :heavy_multiplication_x:  Package has no continuous integration checks.
+- :heavy_multiplication_x: Some goodpractice linters failed.
 - :heavy_multiplication_x: Package contains unexpected files.
 - :heavy_multiplication_x: Default GitHub branch of 'master' is not acceptable.
 - :heavy_check_mark: This is a statistical package which complies with all applicable standards

--- a/tests/testthat/_snaps/extra-checks/checks-print.md
+++ b/tests/testthat/_snaps/extra-checks/checks-print.md
@@ -11,6 +11,7 @@ v 'DESCRIPTION' has a BugReports field.
 x Package has no HTML vignettes
 x These functions do not have examples: [pkgstats_from_archive].
 x Package has no continuous integration checks.
+x Some goodpractice linters failed.
 x Package contains unexpected files.
 x Default GitHub branch of 'master' is not acceptable.
 v This is a statistical package which complies with all applicable standards

--- a/tests/testthat/test-list-checks.R
+++ b/tests/testthat/test-list-checks.R
@@ -3,7 +3,7 @@ test_that ("list-checks", {
         chks <- list_pkgchecks (),
         "The following checks are currently implemented"
     )
-    expect_length (chks, 21L)
+    expect_length (chks, 22L)
 
     expect_silent (
         chks2 <- list_pkgchecks (quiet = TRUE)


### PR DESCRIPTION
It closes #245 when merged.

The scope of this PR has expanded beyond flagging the use of sapply_linter from [lintr::undesirable_function_linter](https://github.com/ropensci-review-tools/goodpractice/blob/6429e0f8b37bd7e2eaa532518ac48fe0a818f1e2/R/prep_lintr.R#L13-L15). It now includes all `goodpractice` linting checks whose names start with `lintr_`.

I've added this as a watch check, as it relates to #251 and how `goodpractice` will applied even when it is set to `FALSE`. For this reason, I haven’t made changes to `pkgcheck()` itself, so it will continue to invoke lintr twice when `goodpractice` is set to `TRUE`. I’m open to suggestions on this approach.