### PR TITLE
fix(pkgcheck): Uses `tryCatch()` for ctags

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,9 @@ Authors@R: c(
            comment = c(ORCID = "0000-0003-2172-5265")),
     person("Maëlle", "Salmon", role = "aut"),
     person("Jacob", "Wujciak-Jens", , "jacob@wujciak.de", role = "aut",
-           comment = c(ORCID = "0000-0002-7281-3989"))
+           comment = c(ORCID = "0000-0002-7281-3989")),
+    person(c("Kelli", "F."), "Johnson", , "kelli.johnson@noaa.gov",
+           role = "ctb", comment = c(ORCID = "0000-0002-5149-451X"))
   )
 Description: Check whether a package is ready for submission to rOpenSci's
     peer review system.

--- a/R/pkgcheck-fn.R
+++ b/R/pkgcheck-fn.R
@@ -36,14 +36,17 @@ pkgcheck <- function (path = ".", goodpractice = TRUE,
 
     # Ensure that ctags works properly (#54):
     if (interactive ()) {
-        if (!suppressMessages (pkgstats::ctags_test ())) {
-            stop (
-                "The 'pkgstats' package requires 'ctags' which does ",
-                "not seem to be installed correctly.\nSee ",
-                "https://docs.ropensci.org/pkgstats/articles/installation.html",
-                " for details on how to install 'ctags'."
-            )
-        }
+        tryCatch (
+            pkgstats::ctags_test (),
+            error = function (e) {
+                stop (
+                    "The 'pkgstats' package requires 'ctags' which does ",
+                    "not seem to be installed correctly.\nSee ",
+                    "https://docs.ropensci.org/pkgstats/articles/installation.html",
+                    " for details on how to install 'ctags'."
+                )
+          }
+        )
     }
 
     s <- pkgstats_info (path, use_cache)


### PR DESCRIPTION
The if statement in `pkgcheck()` to see if ctags was available was not reporting the statement from the if statement because pkgstats::has_ctags() was using `stop()` rather than returning a TRUE FALSE value. TRUE is only returned if ctags is available.

Close #254

Currently, if you do not have ctags then `pkgcheck::pkgcheck()` will return the following on a Windows machine using VS Code
```
r$> pkgcheck()
Error in value[[3L]](cond) : 
  The 'pkgstats' package requires 'ctags' which does not seem to be installed correctly.
See https://docs.ropensci.org/pkgstats/articles/installation.html for details on how to install 'ctags'.
```
I no longer saw the need for the if statement so the inner if statement has been removed and TRUE will be returned if `tryCatch()` is successful but it is not saved to an object but it could be if that would be helpful.