### PR TITLE
fix info-ci

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgcheck
 Title: rOpenSci Package Checks
-Version: 0.1.2.191
+Version: 0.1.2.192
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgcheck
 Title: rOpenSci Package Checks
-Version: 0.1.2.192
+Version: 0.1.2.193
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgcheck
 Title: rOpenSci Package Checks
-Version: 0.1.2.190
+Version: 0.1.2.191
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265")),

--- a/R/info-ci.R
+++ b/R/info-ci.R
@@ -183,9 +183,9 @@ ci_results_gh <- function (path) {
             run_number = 101:102,
             created_at = rep ("2025-01-01T00:00:01Z", 2L)
         )
-        runs <- list (total_count = 2L, workflow_runs = wf)
+        runs <- list (total_count = nrow (wf), workflow_runs = wf)
     } else {
-
+        # These lines can not be tested:
         body <- httr2::request (url) |>
             httr2::req_perform ()
         runs <- httr2::resp_body_json (body, simplify = TRUE)

--- a/R/info-ci.R
+++ b/R/info-ci.R
@@ -173,7 +173,23 @@ ci_results_gh <- function (path) {
         "/actions/runs"
     )
 
-    runs <- jsonlite::fromJSON (url)
+    if (is_test_env ()) {
+        wf <- data.frame (
+            id = 1:2,
+            name = c ("R-CMD-check.yaml", "test-coverage.yaml"),
+            status = rep ("completed", 2L),
+            conclusion = rep ("success", 2L),
+            head_sha = c ("abcdefgh123456", "123456abcdefgh"),
+            run_number = 101:102,
+            created_at = rep ("2025-01-01T00:00:01Z", 2L)
+        )
+        runs <- list (total_count = 2L, workflow_runs = wf)
+    } else {
+
+        body <- httr2::request (url) |>
+            httr2::req_perform ()
+        runs <- httr2::resp_body_json (body, simplify = TRUE)
+    }
 
     if (!"total_count" %in% names (runs)) {
         return (NULL)

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/pkgcheck",
   "issueTracker": "https://github.com/ropensci-review-tools/pkgcheck/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.1.2.190",
+  "version": "0.1.2.191",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/pkgcheck",
   "issueTracker": "https://github.com/ropensci-review-tools/pkgcheck/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.1.2.192",
+  "version": "0.1.2.193",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/pkgcheck",
   "issueTracker": "https://github.com/ropensci-review-tools/pkgcheck/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.1.2.191",
+  "version": "0.1.2.192",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/tests/testthat/_snaps/extra-checks/checks-extra.html
+++ b/tests/testthat/_snaps/extra-checks/checks-extra.html
@@ -29,7 +29,7 @@ $(document).ready(function(){
 <li>✅ ‘DESCRIPTION’ has a BugReports field.</li>
 <li>❌ Package has no HTML vignettes</li>
 <li>❌ These functions do not have examples: [pkgstats_from_archive].</li>
-<li>❌ Package fails continuous integration checks, and has no badges on README</li>
+<li>✅ Package has continuous integration checks, but no badges on README</li>
 <li>❌ Package contains unexpected files.</li>
 <li>❌ Default GitHub branch of ‘master’ is not acceptable.</li>
 <li>✅ This is a statistical package which complies with all applicable standards</li>

--- a/tests/testthat/_snaps/extra-checks/checks-extra.md
+++ b/tests/testthat/_snaps/extra-checks/checks-extra.md
@@ -11,7 +11,7 @@ git hash: [](https://github.com/ropensci-review-tools/pkgstats/tree/)
 - :heavy_check_mark: 'DESCRIPTION' has a BugReports field.
 - :heavy_multiplication_x: Package has no HTML vignettes
 - :heavy_multiplication_x: These functions do not have examples: [pkgstats_from_archive].
-- :heavy_multiplication_x:  Package fails continuous integration checks, and has no badges on README
+- :heavy_check_mark:  Package has continuous integration checks, but no badges on README
 - :heavy_multiplication_x: Package contains unexpected files.
 - :heavy_multiplication_x: Default GitHub branch of 'master' is not acceptable.
 - :heavy_check_mark: This is a statistical package which complies with all applicable standards

--- a/tests/testthat/_snaps/extra-checks/checks-print.md
+++ b/tests/testthat/_snaps/extra-checks/checks-print.md
@@ -10,7 +10,7 @@ v 'DESCRIPTION' has a URL field.
 v 'DESCRIPTION' has a BugReports field.
 x Package has no HTML vignettes
 x These functions do not have examples: [pkgstats_from_archive].
-x Package fails continuous integration checks, and has no badges on README
+v Package has continuous integration checks, but no badges on README
 x Package contains unexpected files.
 x Default GitHub branch of 'master' is not acceptable.
 v This is a statistical package which complies with all applicable standards

--- a/tests/testthat/test-check-ci.R
+++ b/tests/testthat/test-check-ci.R
@@ -7,13 +7,27 @@ test_that ("check ci", {
     expect_length (ci_out, 3L)
     expect_named (ci_out, c ("check_pass", "summary", "print"))
 
+    expect_true (ci_out$check_pass)
+    expect_equal (
+        ci_out$summary,
+        " Package has continuous integration checks."
+    )
+    expect_gt (length (ci_out$print), 5L)
+    # Most 'print' lines have something:
+    nlines <- length (ci_out$print)
+    non_empty_lines <- length (which (nzchar (ci_out$print)))
+    expect_gt (non_empty_lines / nlines, 0.6)
+
+    skip_on_os ("mac")
+
+    i <- grep ("CMD", checks$info$github_workflows$name)
+    checks$info$github_workflows$conclusion [i] <- "fail"
+    ci_out <- output_pkgchk_ci (checks)
     expect_false (ci_out$check_pass)
     expect_equal (
         ci_out$summary,
         " Package fails continuous integration checks."
     )
-    expect_length (ci_out$print, 1L)
-    expect_true (!nzchar (ci_out$print))
 
     checks$checks$has_url <- FALSE
     ci_out <- output_pkgchk_ci (checks)
@@ -28,28 +42,6 @@ test_that ("check ci", {
     expect_length (ci_out$print, 1L)
     expect_true (!nzchar (ci_out$print))
     checks$checks$has_url <- TRUE
-
-    skip_on_os ("mac")
-
-    # workflow has 1 workflow named "Update pkgstats Results"
-    checks$info$github_workflows$name <- "R CMD check"
-    ci_out <- output_pkgchk_ci (checks)
-    expect_true (ci_out$check_pass)
-    expect_equal (
-        ci_out$summary,
-        " Package has continuous integration checks."
-    )
-    expect_gt (length (ci_out$print), 1L)
-
-    checks$info$github_workflows$conclusion <- "fail"
-    ci_out <- output_pkgchk_ci (checks)
-    expect_false (ci_out$check_pass)
-    expect_equal (
-        ci_out$summary,
-        " Package fails continuous integration checks."
-    )
-    expect_length (ci_out$print, 1L)
-    expect_true (!nzchar (ci_out$print))
 
     checks$info$badges <- character (0L)
     ci_out <- output_pkgchk_ci (checks)


### PR DESCRIPTION
jsonlite was making direct calls, with no mocked results, and so tests were not repeatable, and often failed