### PR TITLE
Improve convert_path tests

### DIFF
--- a/tests/testthat/test-path-fns.R
+++ b/tests/testthat/test-path-fns.R
@@ -1,24 +1,104 @@
 testthat::skip_on_os ("windows")
 testthat::skip_on_os ("mac")
 
+err_msg <- "Could not find unambiguous project root"
+
+with_descriptions <- function (dir_paths, code) {
+    f_descs <- fs::path (dir_paths, "DESCRIPTION")
+    withr::with_file (
+        f_descs,
+        {
+            desc <- system.file ("DESCRIPTION", package = "pkgcheck")
+            sapply (f_descs, \(f_desc) fs::file_copy (desc, f_desc, overwrite = TRUE))
+            code
+        }
+    )
+}
+
+pkgname <- function () paste0 (
+    sample (c (letters, LETTERS), 8),
+    collapse = ""
+)
+
 # Results on non-Linux systems are equal paths, but not identical
 
-test_that ("pkgcheck", {
+test_that ("convert_path works with pkgdir same as and subdir of git root", {
+    git_root <- fs::as_fs_path(withr::local_tempdir (pkgname()))
+    sub_dir <- fs::as_fs_path(withr::local_tempdir ("subdir", tmpdir = git_root))
+    gert::git_init (git_root)
+    with_descriptions (git_root, {
+        # If description is in git_root,
+        # convert_path returns git_root
+        # regardless of whether git_root or subdir is provided
+        expect_identical (convert_path (git_root), git_root)
+        expect_identical (convert_path (sub_dir), git_root)
+    })
+    with_descriptions (sub_dir, {
+        # If description is in subdir,
+        # convert_path returnssubdir
+        # regardless of whether git_root or subdir is provided
+        expect_identical (convert_path (git_root), sub_dir)
+        expect_identical (convert_path (sub_dir), sub_dir)
+    })
+    with_descriptions (c(git_root, sub_dir), {
+        # If description in both subdir and git root
+        # return git root, ignore description in subdir
+        expect_identical (convert_path (git_root), git_root)
+        expect_identical (convert_path (sub_dir), git_root)
+    })
+})
 
-    pkgname <- paste0 (
-        sample (c (letters, LETTERS), 8),
-        collapse = ""
-    )
-    pkg_root <- fs::dir_create (fs::path_temp (), pkgname)
-    path <- fs::dir_create (pkg_root, "subdir")
-    f_desc <- fs::path (path, "DESCRIPTION")
-    desc <- system.file ("DESCRIPTION", package = "pkgcheck")
-    fs::file_copy (desc, f_desc, overwrite = TRUE)
+test_that ("convert_path works with pkg outside of git repo", {
+    pkg_root <- fs::as_fs_path(withr::local_tempdir (pkgname()))
+    sub_dir <- fs::as_fs_path(withr::local_tempdir ("subdir", tmpdir = pkg_root))
+
+    with_descriptions (pkg_root, {
+        # If description is in pkg_root, return it
+        expect_identical (convert_path (pkg_root), pkg_root)
+        expect_identical (convert_path (sub_dir), pkg_root)
+    })
+    with_descriptions (sub_dir, {
+        # If description is in subdir,
+        # convert_path returnssubdir
+        # regardless of whether git_root or subdir is provided
+        expect_identical (convert_path (pkg_root), sub_dir)
+        expect_identical (convert_path (sub_dir), sub_dir)
+    })
+    with_descriptions (c(pkg_root, sub_dir), {
+        # If description in both subdir and git root
+        # return whichever is passed in
+        expect_identical (convert_path (pkg_root), pkg_root)
+        expect_identical (convert_path (sub_dir), sub_dir)
+    })
+})
+
+test_that ("convert_path errors if no description found", {
+    pkg_root <- fs::as_fs_path(withr::local_tempdir (pkgname()))
+    sub_dir <- fs::as_fs_path(withr::local_tempdir ("subdir", tmpdir = pkg_root))
+    expect_error (convert_path (pkg_root), err_msg)
+    expect_error (convert_path (sub_dir), err_msg)
     gert::git_init (pkg_root)
+    expect_error (convert_path (pkg_root), err_msg)
+    expect_error (convert_path (sub_dir), err_msg)
+})
 
-    path_conv <- convert_path (pkg_root)
-    # path_conv should then be subdir:
-    expect_identical (path_conv, path)
-
-    fs::dir_delete (pkg_root)
+test_that ("convert_path errors if description in multiple subdirs", {
+    pkg_root <- fs::as_fs_path(withr::local_tempdir (pkgname()))
+    sub_dirs <- fs::as_fs_path(c(
+        withr::local_tempdir ("subdir", tmpdir = pkg_root),
+        withr::local_tempdir ("subdir", tmpdir = pkg_root)
+    ))
+    with_descriptions (sub_dirs, {
+        expect_error (convert_path (pkg_root), err_msg)
+        # without a git repo, if subdir is passed in, the other subdir is ignored
+        expect_identical (convert_path (sub_dirs[1]), sub_dirs[1])
+        expect_identical (convert_path (sub_dirs[2]), sub_dirs[2])
+    })
+    gert::git_init (pkg_root)
+    with_descriptions (sub_dirs, {
+        expect_error (convert_path (pkg_root), err_msg)
+        # with a git repo, error is raised if either subdir is provided
+        expect_error (convert_path (sub_dirs[1]), err_msg)
+        expect_error (convert_path (sub_dirs[2]), err_msg)
+    })
 })


### PR DESCRIPTION
Main goal here was to cover more scenarios for convert_path.  Added some helper functions to keep it DRYer.

- use withr instead of explicitly deleting files/folder
- test cases without a git repo
- test cases that should raise an error