### PR TITLE
Substitute `check_type` for `check_pass` in Vignette Sec 3.2a

### DIFF
--- a/vignettes/extending-checks.Rmd
+++ b/vignettes/extending-checks.Rmd
@@ -423,16 +423,16 @@ named `check_type`, specified as a string with conditions for
 &#9989; or &#10060; symbols with &#128064;. For example, a check which should
 issue &#9989; on pass yet &#128064; on fail would be specified as,
 ```{r, eval = FALSE}
-out$check_pass <- "pass_watch"
+out$check_type <- "pass_watch"
 ```
 A check which should only issue &#128064; on fail and nothing on success would
 be specified as,
 ```{r, eval = FALSE}
-out$check_pass <- "none_watch"
+out$check_type <- "none_watch"
 ```
 A check which should issue &#128064; on success and nothing on failure would be specified as,
 ```{r, eval = FALSE}
-out$check_pass <- "watch_none"
+out$check_type <- "watch_none"
 ```
 
 


### PR DESCRIPTION
Unless I misunderstood, I think in the [vignette section](https://docs.ropensci.org/pkgcheck/articles/extending-checks.html#a-check-types) describing the use of the new `check_type`, the examples should use `out$check_type` instead of `out$check_pass`