### PR TITLE
Add air.toml to .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,3 +20,4 @@
 ^makefile$
 ^vignettes/makefile$
 data-raw/
+^air\.toml$


### PR DESCRIPTION
I just noticed after #297 I forgot to add `air.toml` to `.Rbuildignore`