### PR TITLE
suppress warnings on saveRDS call in cache fn #367

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgcheck
 Title: rOpenSci Package Checks
-Version: 0.1.2.310
+Version: 0.1.2.311
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265")),

--- a/R/cache.R
+++ b/R/cache.R
@@ -149,9 +149,11 @@ cache_pkgcheck_component <- function (path,
 
         # writing to cache_dir fails on some GHA windows machines.
         if (fs::dir_exists (cache_dir)) {
-            chk <- tryCatch (
-                saveRDS (out, cache_file),
-                error = function (e) NULL
+            suppressWarnings (
+                chk <- tryCatch (
+                    saveRDS (out, cache_file),
+                    error = function (e) NULL
+                )
             )
         }
     }

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/pkgcheck",
   "issueTracker": "https://github.com/ropensci-review-tools/pkgcheck/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.1.2.310",
+  "version": "0.1.2.311",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",


### PR DESCRIPTION
New goodpractice triggers a warning there that 'pacakge:Rcpp' may not be available when loading. That should clearly have nothing to do with 'saveRDS', and so have simply been suppressed.