### PR TITLE
run test-extra-checks on all OSs, but skip snapshots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgcheck
 Title: rOpenSci Package Checks
-Version: 0.1.2.326
+Version: 0.1.2.327
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265")),

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/pkgcheck",
   "issueTracker": "https://github.com/ropensci-review-tools/pkgcheck/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.1.2.326",
+  "version": "0.1.2.327",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/tests/testthat/test-extra-checks.R
+++ b/tests/testthat/test-extra-checks.R
@@ -1,12 +1,6 @@
 test_all <- identical (Sys.getenv ("MPADGE_LOCAL"), "true") ||
     identical (Sys.getenv ("GITHUB_JOB"), "test-coverage")
 
-# These tests should not be skipped because the `!test_all` condition then
-# includes the `pkgcheck` workflow itself, which then reduces coverage.
-# skip_if (!test_all)
-testthat::skip_on_os ("windows")
-testthat::skip_on_os ("mac")
-
 test_that ("extra checks", {
 
     checks <- make_check_data_internal (cleanup = FALSE)
@@ -44,14 +38,18 @@ test_that ("extra checks", {
     f_md <- fs::path (md_dir, "checks-extra.md")
     writeLines (md, con = f_md)
 
-    testthat::expect_snapshot_file (file.path (md_dir, "checks-extra.md"))
+    if (Sys.info () [["sysname"]] == "Linux") {
+        testthat::expect_snapshot_file (file.path (md_dir, "checks-extra.md"))
+    }
 
     h <- render_md2html (md, open = FALSE)
     f_html <- file.path (md_dir, "checks-extra.html")
     file.copy (h, f_html)
     edit_html (f_html) # from clean-snapshots.R
 
-    testthat::expect_snapshot_file (f_html)
+    if (Sys.info () [["sysname"]] == "Linux") {
+        testthat::expect_snapshot_file (f_html)
+    }
 
     # Then snapshot tests of print & summary methods
     # This loads goodpractice, so first do that to avoid load message
@@ -65,7 +63,9 @@ test_that ("extra checks", {
     f_md2 <- fs::path (md_dir, "checks-print.md")
     writeLines (md, con = f_md2)
 
-    testthat::expect_snapshot_file (file.path (md_dir, "checks-print.md"))
+    if (Sys.info () [["sysname"]] == "Linux") {
+        testthat::expect_snapshot_file (file.path (md_dir, "checks-print.md"))
+    }
 
     fs::file_delete (c (f_md, f_html, f_tmp, f_md2))
     fs::dir_delete (checks$pkg$path)


### PR DESCRIPTION
On mac/windows; the snapshots generate extra lines and different paths on those, but otherwise all the actual tests should now work