### PR TITLE
fix bug in extracting pkg url

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgcheck
 Title: rOpenSci Package Checks
-Version: 0.1.3.003
+Version: 0.1.3.004
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265")),

--- a/R/info-from-desc.R
+++ b/R/info-from-desc.R
@@ -59,6 +59,12 @@ pkginfo_url_from_desc <- function (path, type = "URL") {
     if (length (u) > 1) {
         u <- u [which (!grepl ("\\.io", u))]
     }
+    if (type == "URL" && grepl ("github\\.io", u, ignore.case = TRUE)) {
+        u <- pkginfo_url_from_desc (path, type = "BugReports")
+        if (grepl ("issues(\\/?)$", u)) {
+            u <- gsub ("issues(\\/?)$", "", u)
+        }
+    }
 
     u <- gsub (",|\\s+", "", u)
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/pkgcheck",
   "issueTracker": "https://github.com/ropensci-review-tools/pkgcheck/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.1.3.003",
+  "version": "0.1.3.004",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",


### PR DESCRIPTION
https://github.com/ropensci/software-review/issues/740 returns failed URL check; this fixes