### PR TITLE
fix minor bug in sub-directory check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgcheck
 Title: rOpenSci Package Checks
-Version: 0.1.3.005
+Version: 0.1.3.006
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # pkgcheck News
 
-## 0.1.3
+## 0.1.3.00x (current dev version)
+
+- Fix bug in sub-directory check
 
 ----
 

--- a/R/format-checks.R
+++ b/R/format-checks.R
@@ -136,7 +136,9 @@ checks_to_markdown <- function (checks, render = FALSE) {
 get_subdir_text <- function (checks) {
 
     subdir_txt <- NULL
-    if (checks$pkg$path != checks$pkg$repo_path) {
+    path <- fs::path_abs (checks$pkg$path)
+    repo_path <- fs::path_abs (checks$pkg$repo_path)
+    if (!identical (path, repo_path)) {
         subdir <- fs::path_rel (checks$pkg$path, checks$pkg$repo_path)
         subdir_txt <- c ("", paste0 (
             "NOTE: R package is in the '",

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/pkgcheck",
   "issueTracker": "https://github.com/ropensci-review-tools/pkgcheck/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.1.3.005",
+  "version": "0.1.3.006",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",


### PR DESCRIPTION
Previous version failed if paths differed by a terminal '\'