### PR TITLE
Add torch/LibTorch installation for packages depending on torch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -289,6 +289,7 @@ RUN install2.r \
   terra \
   tidymodels \
   tidyverse \
+  torch \
   xts \
   zoo
 
@@ -317,10 +318,7 @@ RUN /root/.virtualenvs/r-reticulate/bin/pip install earthengine-api
 RUN Rscript -e 'arrow::install_arrow()'
 
 # Other general-purpose installation commands:
-# torch requires LibTorch to be installed within the image,
-# otherwise package builds and tests fail. See kindling #784:
-RUN install2.r torch && \
-  Rscript -e 'torch::install_torch()'
+RUN Rscript -e 'torch::install_torch()'
 
 # Plus current ubuntu-unstable versions cause failed linkage of sf to GEOS, so
 # need to reinstall both 'sf' and 'terra' without bspm:

--- a/Dockerfile
+++ b/Dockerfile
@@ -316,6 +316,12 @@ RUN /root/.virtualenvs/r-reticulate/bin/pip install earthengine-api
 # support doesn't work without re-install/compile:
 RUN Rscript -e 'arrow::install_arrow()'
 
+# Other general-purpose installation commands:
+# torch requires LibTorch to be installed within the image,
+# otherwise package builds and tests fail. See kindling #784:
+RUN install2.r torch && \
+  Rscript -e 'torch::install_torch()'
+
 # Plus current ubuntu-unstable versions cause failed linkage of sf to GEOS, so
 # need to reinstall both 'sf' and 'terra' without bspm:
 RUN Rscript -e 'bspm::disable();install.packages(c("sf","terra"));bspm::enable()'


### PR DESCRIPTION
As discussed in ropensci/software-review#784, packages importing torch fail to build in the check environment because LibTorch is not available. This installs the torch package and LibTorch at image build time, following the placement suggested by @mpadge. With TORCH_INSTALL=1 set, the same commit passes all checks (see joshuamarie/kindling#34).