### PR TITLE
skip lots of tests on cran

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgcheck
 Title: rOpenSci Package Checks
-Version: 0.2.0.018
+Version: 0.2.0.019
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgcheck
 Title: rOpenSci Package Checks
-Version: 0.2.0.019
+Version: 0.2.0.020
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265")),

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/pkgcheck",
   "issueTracker": "https://github.com/ropensci-review-tools/pkgcheck/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.2.0.019",
+  "version": "0.2.0.020",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/pkgcheck",
   "issueTracker": "https://github.com/ropensci-review-tools/pkgcheck/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.2.0.18",
+  "version": "0.2.0.019",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -53,7 +53,10 @@
   "contributor": [
     {
       "@type": "Person",
-      "givenName": ["Kelli", "F."],
+      "givenName": [
+        "Kelli",
+        "F."
+      ],
       "familyName": "Johnson",
       "email": "kelli.johnson@noaa.gov",
       "@id": "https://orcid.org/0000-0002-5149-451X"
@@ -390,12 +393,20 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=withr"
     },
-    "SystemRequirements": null
+    "SystemRequirements": {}
   },
   "fileSize": "493.595KB",
   "releaseNotes": "https://github.com/ropensci-review-tools/pkgcheck/blob/main/NEWS.md",
   "readme": "https://github.com/ropensci-review-tools/pkgcheck/blob/main/README.md",
-  "contIntegration": ["https://github.com/ropensci-review-tools/pkgcheck/actions/workflows/R-CMD-check.yaml", "https://app.codecov.io/gh/ropensci-review-tools/pkgcheck"],
+  "contIntegration": [
+    "https://github.com/ropensci-review-tools/pkgcheck/actions/workflows/R-CMD-check.yaml",
+    "https://app.codecov.io/gh/ropensci-review-tools/pkgcheck"
+  ],
   "developmentStatus": "https://www.repostatus.org/#active",
-  "keywords": ["compliance-automation", "r", "software-analysis", "software-checking"]
+  "keywords": [
+    "compliance-automation",
+    "r",
+    "software-analysis",
+    "software-checking"
+  ]
 }

--- a/tests/testthat/test-check-fns-have-exs.R
+++ b/tests/testthat/test-check-fns-have-exs.R
@@ -1,3 +1,5 @@
+skip_on_cran ()
+
 test_that ("check functions have exs", {
 
     checks <- make_check_data ()

--- a/tests/testthat/test-check-fns-have-return-vals.R
+++ b/tests/testthat/test-check-fns-have-return-vals.R
@@ -1,3 +1,5 @@
+skip_on_cran ()
+
 test_that ("check fns have return values", {
 
     checks <- make_check_data ()

--- a/tests/testthat/test-check-left-assign.R
+++ b/tests/testthat/test-check-left-assign.R
@@ -1,6 +1,8 @@
 test_all <- identical (Sys.getenv ("MPADGE_LOCAL"), "true") ||
     identical (Sys.getenv ("GITHUB_JOB"), "test-coverage")
 
+skip_on_cran ()
+
 test_that ("check left and global assign", {
 
     checks <- make_check_data ()

--- a/tests/testthat/test-check-license.R
+++ b/tests/testthat/test-check-license.R
@@ -1,3 +1,5 @@
+skip_on_cran ()
+
 test_that ("check license", {
 
     checks <- make_check_data ()

--- a/tests/testthat/test-check-no-r-subdir.R
+++ b/tests/testthat/test-check-no-r-subdir.R
@@ -1,3 +1,5 @@
+skip_on_cran ()
+
 test_that ("check subdir in R dir", {
 
     checks <- make_check_data ()

--- a/tests/testthat/test-check-num-imports.R
+++ b/tests/testthat/test-check-num-imports.R
@@ -1,3 +1,5 @@
+skip_on_cran ()
+
 test_that ("check num imports", {
 
     checks <- make_check_data ()

--- a/tests/testthat/test-check-obsolete-pkg-deps.R
+++ b/tests/testthat/test-check-obsolete-pkg-deps.R
@@ -1,4 +1,6 @@
-test_that ("check num imports", {
+skip_on_cran ()
+
+test_that ("check obsolete pkg deps", {
 
     checks <- make_check_data ()
 

--- a/tests/testthat/test-check-orchid-roi.R
+++ b/tests/testthat/test-check-orchid-roi.R
@@ -1,3 +1,5 @@
+skip_on_cran ()
+
 test_that ("check ORCID ID", {
     checks <- make_check_data ()
     ci_out <- output_pkgchk_has_orcid (checks)

--- a/tests/testthat/test-check-pkgname-available.R
+++ b/tests/testthat/test-check-pkgname-available.R
@@ -1,3 +1,5 @@
+skip_on_cran ()
+
 test_that ("check num imports", {
 
     checks <- make_check_data ()

--- a/tests/testthat/test-check-renv.R
+++ b/tests/testthat/test-check-renv.R
@@ -1,3 +1,5 @@
+skip_on_cran ()
+
 test_that ("check num imports", {
 
     checks <- make_check_data ()

--- a/tests/testthat/test-check-repo-has-website.R
+++ b/tests/testthat/test-check-repo-has-website.R
@@ -1,3 +1,5 @@
+skip_on_cran ()
+
 test_that ("check repo has a website", {
 
     checks <- make_check_data ()

--- a/tests/testthat/test-check-repo-not-fork.R
+++ b/tests/testthat/test-check-repo-not-fork.R
@@ -1,3 +1,5 @@
+skip_on_cran ()
+
 test_that ("check repo is not a fork", {
 
     checks <- make_check_data ()

--- a/tests/testthat/test-check-scrap.R
+++ b/tests/testthat/test-check-scrap.R
@@ -2,6 +2,8 @@ test_all <- (identical (Sys.getenv ("MPADGE_LOCAL"), "true") ||
     identical (Sys.getenv ("GITHUB_JOB"), "test-coverage") ||
     identical (Sys.getenv ("GITHUB_JOB"), "pkgcheck"))
 
+skip_on_cran ()
+
 test_that ("check scrap", {
 
     checks <- make_check_data ()

--- a/tests/testthat/test-check-unique-fn-names.R
+++ b/tests/testthat/test-check-unique-fn-names.R
@@ -1,3 +1,5 @@
+skip_on_cran ()
+
 test_that ("check unique functions names", {
 
     checks <- make_check_data ()

--- a/tests/testthat/test-check-uses-dontrun.R
+++ b/tests/testthat/test-check-uses-dontrun.R
@@ -1,3 +1,5 @@
+skip_on_cran ()
+
 test_that ("check examples dont use dontrun", {
 
     checks <- make_check_data ()

--- a/tests/testthat/test-extra-checks.R
+++ b/tests/testthat/test-extra-checks.R
@@ -1,6 +1,8 @@
 test_all <- identical (Sys.getenv ("MPADGE_LOCAL"), "true") ||
     identical (Sys.getenv ("GITHUB_JOB"), "test-coverage")
 
+skip_on_cran ()
+
 test_that ("extra checks", {
 
     checks <- make_check_data_internal (cleanup = FALSE)

--- a/vignettes/extending-checks.Rmd
+++ b/vignettes/extending-checks.Rmd
@@ -251,7 +251,7 @@ This allows specific checks to be defined locally, and run by passing the name
 of the environment in which those checks are defined in this parameter. This
 section illustrates the process using the bundled "tarball" (that is, `.tar.gz`
 file) of one version of [the `pkgstats`
-package](https://github.com/ropensc-review-tools/pkgstats) included with that
+package](https://github.com/ropensci-review-tools/pkgstats) included with that
 package.
 
 ```{r pkgstats-check, eval = FALSE}


### PR DESCRIPTION
Because most of them call they gh api, which fails on cran because no token