### PR TITLE
Add Eric Scott as author

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,9 @@ Authors@R: c(
     person("Katrina", "Brock", , "katrinabrock266@gmail.com", role = "ctb",
            comment = c(ORCID = "0009-0003-4678-9545")),
     person("Andy", "Teucher", , "andy.teucher@gmail.com", role = "aut",
-           comment = c(ORCID = "0000-0002-7840-692X"))
+           comment = c(ORCID = "0000-0002-7840-692X")),
+    person("Eric R.", "Scott", role = "aut",
+           comment = c(ORCID = "0000-0002-7430-7879"))
   )
 Description: Check whether a package is ready for submission to the 'rOpenSci'
     peer review system ('rOpenSci' authors, 2021;


### PR DESCRIPTION
In response to https://github.com/ropensci-review-tools/pkgcheck/pull/243#issuecomment-5511353307, I've added myself as an author.  However, "ctb" might make more sense?  Either way is fine with me!